### PR TITLE
Add missing user profile table to database schema

### DIFF
--- a/system/db.sql
+++ b/system/db.sql
@@ -8,3 +8,16 @@ CREATE TABLE IF NOT EXISTS `users` (
   PRIMARY KEY (`id`),
   UNIQUE KEY (`email`)
 );
+
+-- Table for additional user details
+CREATE TABLE IF NOT EXISTS `user_profiles` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `user_id` INT NOT NULL,
+  `firstname` VARCHAR(100) NOT NULL,
+  `lastname` VARCHAR(100) NOT NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_user_profiles_user`
+    FOREIGN KEY (`user_id`)
+    REFERENCES `users`(`id`)
+    ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
- fix registration failure by creating `user_profiles` table in SQL schema

## Testing
- `php -l api/register.php`
- `php -l api/login.php`
- `php -l api/medikamente.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac8a56dd94832197f0669e1110270c