### PR TITLE
Add WebKit backdrop-filter for Safari compatibility

### DIFF
--- a/css/dashboard-style.css
+++ b/css/dashboard-style.css
@@ -23,6 +23,7 @@ html, body {
 }
 .overlay {
   background: rgba(255, 255, 255, 0.6);
+  -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
   padding: 2rem;
   border-radius: 25px;

--- a/css/index-style.css
+++ b/css/index-style.css
@@ -24,6 +24,7 @@ body, html {
   background: rgba(0, 0, 0, 0.4); /* optional for readability */
   padding: 2rem;
   border-radius: 20px;
+  -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
 }
 

--- a/css/login-style.css
+++ b/css/login-style.css
@@ -20,6 +20,7 @@ html, body {
 }
 .overlay {
   background: rgba(0, 0, 0, 0.4);
+  -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
   padding: 2rem;
   border-radius: 20px;

--- a/css/medikamente-style.css
+++ b/css/medikamente-style.css
@@ -22,6 +22,7 @@ html, body {
 }
 .overlay {
   background: rgba(0,0,0,0.4);
+  -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
   padding: 2rem;
   border-radius: 20px;

--- a/css/profile-style.css
+++ b/css/profile-style.css
@@ -22,6 +22,7 @@ html, body {
 }
 .overlay {
   background: rgba(0, 0, 0, 0.4);
+  -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
   padding: 2rem;
   border-radius: 20px;

--- a/css/register-style.css
+++ b/css/register-style.css
@@ -20,6 +20,7 @@ html, body {
 }
 .overlay {
   background: rgba(0, 0, 0, 0.4);
+  -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
   padding: 2rem;
   border-radius: 20px;


### PR DESCRIPTION
## Summary
- add `-webkit-backdrop-filter: blur(4px);` alongside existing `backdrop-filter` in key stylesheets for Safari support

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8d018c988321b1c9f58a9c182d49