### PR TITLE
Use utility classes for hidden weekdays and errors

### DIFF
--- a/css/medikamente-style.css
+++ b/css/medikamente-style.css
@@ -144,3 +144,12 @@ html, body {
   background: #2e318d;
   color: white;
 }
+
+/* 9. Utility classes */
+.is-hidden {
+  display: none;
+}
+
+.error-message {
+  color: white;
+}

--- a/js/medikamente.js
+++ b/js/medikamente.js
@@ -50,7 +50,7 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     } catch (err) {
       console.error(err);
-      list.innerHTML = `<p style="color:white;">${err.message}</p>`;
+      list.innerHTML = `<p class="error-message">${err.message}</p>`;
     }
   }
 

--- a/medikamente.html
+++ b/medikamente.html
@@ -27,8 +27,8 @@
         </select>
 
         <!-- zunächst ausgeblendet -->
-        <label id="weekdayLabel" for="weekday" style="display:none;">Wochentag:</label>
-        <select id="weekday" style="display:none;">
+        <label id="weekdayLabel" for="weekday" class="is-hidden">Wochentag:</label>
+        <select id="weekday" class="is-hidden">
           <option value="0">Sonntag</option>
           <option value="1">Montag</option>
           <option value="2">Dienstag</option>


### PR DESCRIPTION
## Summary
- Replace inline `display:none` for weekly fields with reusable `.is-hidden` class
- Swap inline error color for `.error-message` styling in JS
- Define `.is-hidden` and `.error-message` utility classes in medication styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8d05c3088321863ef78bad7dc8af