### PR TITLE
Add security headers and content types for API endpoints

### DIFF
--- a/api/dashboard.php
+++ b/api/dashboard.php
@@ -2,6 +2,9 @@
 // dashboard.php
 ini_set('session.cookie_httponly', 1);
 session_start();
+header('Content-Type: text/html');
+header('X-Content-Type-Options: nosniff');
+header('Cache-Control: max-age=31536000, immutable');
 
 if (!isset($_SESSION['user_id'])) {
     header('Location: login.html');

--- a/api/login.php
+++ b/api/login.php
@@ -4,6 +4,8 @@ ini_set('session.cookie_httponly', 1);
 // ini_set('session.cookie_secure', 1); // if using HTTPS
 session_start();
 header('Content-Type: application/json');
+header('X-Content-Type-Options: nosniff');
+header('Cache-Control: max-age=31536000, immutable');
 
 require_once '../system/config.php';
 

--- a/api/logout.php
+++ b/api/logout.php
@@ -6,6 +6,9 @@ session_destroy();
 
 // Return a success response instead of redirecting
 header('Content-Type: application/json');
+header('X-Content-Type-Options: nosniff');
+header('Cache-Control: max-age=31536000, immutable');
 echo json_encode(["status" => "success"]);
 exit;
+
 ?>

--- a/api/medikamente.php
+++ b/api/medikamente.php
@@ -3,6 +3,8 @@
 ini_set('session.cookie_httponly', 1);
 session_start();
 header('Content-Type: application/json');
+header('X-Content-Type-Options: nosniff');
+header('Cache-Control: max-age=31536000, immutable');
 
 require_once '../system/config.php';
 

--- a/api/profile.php
+++ b/api/profile.php
@@ -3,6 +3,8 @@
 ini_set('session.cookie_httponly', 1);
 session_start();
 header('Content-Type: application/json');
+header('X-Content-Type-Options: nosniff');
+header('Cache-Control: max-age=31536000, immutable');
 require_once '../system/config.php';
 
 if (!isset($_SESSION['user_id'])) {

--- a/api/profile/createProfile.php
+++ b/api/profile/createProfile.php
@@ -1,9 +1,11 @@
 <?php
 session_start();
+header('Content-Type: application/json');
+header('X-Content-Type-Options: nosniff');
+header('Cache-Control: max-age=31536000, immutable');
 
 if (!isset($_SESSION['user_id'])) {
     http_response_code(401);
-    header('Content-Type: application/json');
     echo json_encode(["error" => "Unauthorized"]);
     exit;
 }
@@ -15,7 +17,7 @@ require_once '../../system/config.php';
 $loggedInUserId = $_SESSION['user_id'];
 
 // Beispiel-Daten, die eingefügt werden sollen
-$firstname = "Jenny;
+$firstname = "Jenny";
 $lastname = "Wiesner";
 
 try {

--- a/api/profile/readProfile.php
+++ b/api/profile/readProfile.php
@@ -1,9 +1,11 @@
 <?php
 session_start();
+header('Content-Type: application/json');
+header('X-Content-Type-Options: nosniff');
+header('Cache-Control: max-age=31536000, immutable');
 
 if (!isset($_SESSION['user_id'])) {
     http_response_code(401);
-    header('Content-Type: application/json');
     echo json_encode(["error" => "Unauthorized"]);
     exit;
 }

--- a/api/protected.php
+++ b/api/protected.php
@@ -1,11 +1,13 @@
 <?php
 // index.php (API that returns JSON about the logged-in user)
 session_start();
+header('Content-Type: application/json');
+header('X-Content-Type-Options: nosniff');
+header('Cache-Control: max-age=31536000, immutable');
 
 if (!isset($_SESSION['user_id'])) {
     // Instead of redirect, return a 401 JSON response
     http_response_code(401);
-    header('Content-Type: application/json');
     echo json_encode(["error" => "Unauthorized"]);
     exit;
 }

--- a/api/register.php
+++ b/api/register.php
@@ -3,6 +3,8 @@
 ini_set('session.cookie_httponly', 1);
 session_start();
 header('Content-Type: application/json');
+header('X-Content-Type-Options: nosniff');
+header('Cache-Control: max-age=31536000, immutable');
 
 require_once '../system/config.php';
 


### PR DESCRIPTION
## Summary
- add X-Content-Type-Options and long-lived Cache-Control headers across API endpoints
- ensure endpoints return appropriate Content-Type values (JSON or HTML)
- fix malformed example string in profile creation endpoint

## Testing
- `php -l api/*.php api/profile/*.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac8d0b02888321950eab9b7dfd4614