### PR TITLE
feat: add inline feedback for login and profile

### DIFF
--- a/css/login-style.css
+++ b/css/login-style.css
@@ -101,3 +101,16 @@ html, body {
   margin-top: 1rem;
   font-size: 0.9rem;
 }
+
+/* Feedback messages */
+.feedback {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  display: none;
+}
+.feedback.error {
+  color: #ff4d4d;
+}
+.feedback.success {
+  color: #4caf50;
+}

--- a/css/profile-style.css
+++ b/css/profile-style.css
@@ -110,3 +110,16 @@ html, body {
 .buttons button {
   flex: 1;
 }
+
+/* Feedback messages */
+.feedback {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  display: none;
+}
+.feedback.error {
+  color: #ff4d4d;
+}
+.feedback.success {
+  color: #4caf50;
+}

--- a/js/login.js
+++ b/js/login.js
@@ -1,10 +1,25 @@
 // js/login.js
 
-document.getElementById("loginForm").addEventListener("submit", async (e) => {
+const loginForm  = document.getElementById("loginForm");
+const submitBtn  = loginForm.querySelector('button[type="submit"]');
+const feedbackEl = document.createElement('p');
+feedbackEl.className = 'feedback';
+loginForm.appendChild(feedbackEl);
+
+function showFeedback(message, type) {
+  feedbackEl.textContent = message;
+  feedbackEl.className   = `feedback ${type}`;
+  feedbackEl.style.display = message ? 'block' : 'none';
+}
+
+loginForm.addEventListener("submit", async (e) => {
   e.preventDefault();
 
   const email    = document.getElementById("email").value.trim();
   const password = document.getElementById("password").value.trim();
+
+  showFeedback('', '');
+  submitBtn.disabled = true;
 
   try {
     const response = await fetch("api/login.php", {
@@ -17,13 +32,18 @@ document.getElementById("loginForm").addEventListener("submit", async (e) => {
     const result = await response.json();
 
     if (result.status === "success") {
-      // Weiterleitung nach Dashboard.html
-      window.location.href = "dashboard.html";
+      showFeedback('Erfolgreich angemeldet!', 'success');
+      submitBtn.disabled = false;
+      setTimeout(() => {
+        window.location.href = "dashboard.html";
+      }, 500);
     } else {
-      alert(result.message || "Login fehlgeschlagen.");
+      showFeedback(result.message || "Login fehlgeschlagen.", 'error');
+      submitBtn.disabled = false;
     }
   } catch (error) {
     console.error("Login-Fehler:", error);
-    alert("Ein Fehler ist aufgetreten!");
+    showFeedback("Ein Fehler ist aufgetreten!", 'error');
+    submitBtn.disabled = false;
   }
 });

--- a/js/profile.js
+++ b/js/profile.js
@@ -1,5 +1,17 @@
 // js/profile.js
 
+const profileForm = document.getElementById('profileForm');
+const saveBtn     = document.getElementById('saveBtn');
+const feedbackEl  = document.createElement('p');
+feedbackEl.className = 'feedback';
+profileForm.appendChild(feedbackEl);
+
+function showFeedback(message, type) {
+  feedbackEl.textContent = message;
+  feedbackEl.className   = `feedback ${type}`;
+  feedbackEl.style.display = message ? 'block' : 'none';
+}
+
 async function loadProfile() {
   try {
     const res  = await fetch('api/profile.php', {
@@ -14,12 +26,13 @@ async function loadProfile() {
       document.getElementById('birthdate').value = d.birthdate || '';
       // Passwort-Feld leer lassen
       document.getElementById('password').value = '';
+      showFeedback('', '');
     } else {
-      alert('Fehler beim Laden der Profildaten');
+      showFeedback('Fehler beim Laden der Profildaten', 'error');
     }
   } catch (err) {
     console.error(err);
-    alert('Fehler beim Laden der Profildaten');
+    showFeedback('Fehler beim Laden der Profildaten', 'error');
   }
 }
 
@@ -30,11 +43,14 @@ async function saveProfile() {
   const birthdate = document.getElementById('birthdate').value;
 
   if (!name || !email) {
-    alert('Name und E-Mail dürfen nicht leer sein.');
+    showFeedback('Name und E-Mail dürfen nicht leer sein.', 'error');
     return;
   }
 
   const payload = { name, email, password, birthdate };
+
+  showFeedback('', '');
+  saveBtn.disabled = true;
 
   try {
     const res    = await fetch('api/profile.php', {
@@ -46,17 +62,19 @@ async function saveProfile() {
     const result = await res.json();
 
     if (result.status === 'success') {
-      alert('Profil gespeichert!');
+      showFeedback('Profil gespeichert!', 'success');
       // Passwort-Feld löschen, damit nicht erneut gesendet
       document.getElementById('password').value = '';
     } else {
-      alert(result.message || 'Fehler beim Speichern');
+      showFeedback(result.message || 'Fehler beim Speichern', 'error');
     }
   } catch (err) {
     console.error(err);
-    alert('Fehler beim Speichern');
+    showFeedback('Fehler beim Speichern', 'error');
+  } finally {
+    saveBtn.disabled = false;
   }
 }
 
-document.getElementById('saveBtn').addEventListener('click', saveProfile);
+saveBtn.addEventListener('click', saveProfile);
 loadProfile();


### PR DESCRIPTION
## Summary
- show login and profile status messages directly on page instead of alerts
- disable submit buttons while requests are pending for smoother UX
- add reusable CSS styles for inline error and success feedback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aca57f2f648321945e715e6f634703