### PR TITLE
Improve responsive layout and meta tags

### DIFF
--- a/css/dashboard-style.css
+++ b/css/dashboard-style.css
@@ -26,9 +26,19 @@ html, body {
   backdrop-filter: blur(4px);
   padding: 2rem;
   border-radius: 25px;
-  width: 70vw;
-  height: 90vh;
+  width: 90%;
+  max-width: 1200px;
+  height: auto;
+  max-height: 90%;
   overflow-y: auto;
+}
+
+@media (max-width: 768px) {
+  .overlay {
+    width: 100%;
+    max-height: 80%;
+    padding: 1rem;
+  }
 }
 
 /* Header */

--- a/css/medikamente-style.css
+++ b/css/medikamente-style.css
@@ -27,9 +27,16 @@ html, body {
   border-radius: 20px;
   width: 90%;
   max-width: 420px;
-  max-height: 90vh;
+  max-height: 90%;
   overflow-y: auto;
   text-align: center;
+}
+
+@media (max-width: 768px) {
+  .overlay {
+    max-height: 80%;
+    padding: 1rem;
+  }
 }
 
 /* 2. Überschriften */

--- a/css/profile-style.css
+++ b/css/profile-style.css
@@ -27,9 +27,16 @@ html, body {
   border-radius: 20px;
   width: 90%;
   max-width: 360px;
-  max-height: 90vh;
+  max-height: 90%;
   overflow-y: auto;
   text-align: center;
+}
+
+@media (max-width: 768px) {
+  .overlay {
+    max-height: 80%;
+    padding: 1rem;
+  }
 }
 
 /* 2. Überschrift */

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="de">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MediMinder – Willkommen</title>
     <link rel="stylesheet" href="css/index-style.css" />
   </head>

--- a/profile.html
+++ b/profile.html
@@ -2,6 +2,7 @@
 <html lang="de">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Profilübersicht</title>
   <link rel="stylesheet" href="css/profile-style.css" />
 </head>

--- a/protected.html
+++ b/protected.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Protected Page</title>
     <link rel="stylesheet" href="css/style.css" />
   </head>


### PR DESCRIPTION
## Summary
- Add viewport meta tags to index, profile, and protected pages for proper scaling on mobile devices.
- Replace rigid overlay dimensions in CSS with percentage-based sizing and introduce media queries for screens below 768px.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aca58f7fa08321ad0ad84a8d8ebb15