### PR TITLE
Protect pages via session-checked endpoints

### DIFF
--- a/api/medikamente_page.php
+++ b/api/medikamente_page.php
@@ -1,0 +1,11 @@
+<?php
+// api/medikamente_page.php
+ini_set('session.cookie_httponly', 1);
+session_start();
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: ../login.html');
+    exit;
+}
+
+readfile('../medikamente.html');

--- a/api/profile_page.php
+++ b/api/profile_page.php
@@ -1,0 +1,11 @@
+<?php
+// api/profile_page.php
+ini_set('session.cookie_httponly', 1);
+session_start();
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: ../login.html');
+    exit;
+}
+
+readfile('../profile.html');

--- a/dashboard.html
+++ b/dashboard.html
@@ -16,7 +16,7 @@
     <div class="overlay">
       <div class="header">
         <h1>Hallo, <span id="username"></span> :)</h1>
-        <a href="profile.html" class="profile-button" aria-label="Profil">
+        <a href="api/profile_page.php" class="profile-button" aria-label="Profil">
           <i class="fa-solid fa-user"></i>
         </a>
       </div>
@@ -35,7 +35,7 @@
       <h2>Meine Medikamente</h2>
       <div id="medCards" class="med-cards"></div>
 
-      <a href="medikamente.html" class="manage-button">Verwalten</a>
+      <a href="api/medikamente_page.php" class="manage-button">Verwalten</a>
     </div>
   </div>
 

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,5 +1,17 @@
 // js/dashboard.js
 
+// simple authentication check
+(async () => {
+  try {
+    const res = await fetch('api/profile.php', { credentials: 'include' });
+    if (res.status === 401) {
+      window.location.href = 'login.html';
+    }
+  } catch (err) {
+    window.location.href = 'login.html';
+  }
+})();
+
 // aktuelles, ausgewähltes Datum (YYYY-MM-DD)
 let selectedDate = new Date().toISOString().slice(0,10);
 

--- a/js/login.js
+++ b/js/login.js
@@ -17,8 +17,8 @@ document.getElementById("loginForm").addEventListener("submit", async (e) => {
     const result = await response.json();
 
     if (result.status === "success") {
-      // Weiterleitung nach Dashboard.html
-      window.location.href = "dashboard.html";
+      // Weiterleitung über geschützte PHP-Seite
+      window.location.href = "api/dashboard.php";
     } else {
       alert(result.message || "Login fehlgeschlagen.");
     }

--- a/js/medikamente.js
+++ b/js/medikamente.js
@@ -1,4 +1,14 @@
 // js/medikamente.js
+(async () => {
+  try {
+    const res = await fetch('api/profile.php', { credentials: 'include' });
+    if (res.status === 401) {
+      window.location.href = 'login.html';
+    }
+  } catch (err) {
+    window.location.href = 'login.html';
+  }
+})();
 document.addEventListener('DOMContentLoaded', () => {
   const freq    = document.getElementById('frequency');
   const wLabel  = document.getElementById('weekdayLabel');

--- a/js/profile.js
+++ b/js/profile.js
@@ -1,5 +1,16 @@
 // js/profile.js
 
+(async () => {
+  try {
+    const res = await fetch('api/profile.php', { credentials: 'include' });
+    if (res.status === 401) {
+      window.location.href = 'login.html';
+    }
+  } catch (err) {
+    window.location.href = 'login.html';
+  }
+})();
+
 async function loadProfile() {
   try {
     const res  = await fetch('api/profile.php', {

--- a/js/register.js
+++ b/js/register.js
@@ -16,8 +16,8 @@ document.getElementById("registerForm").addEventListener("submit", async functio
     const result = await response.json();
 
     if (result.status === "success") {
-      // Nach erfolgreicher Registrierung zur Login-Seite
-      window.location.href = "dashboard.html";
+      // Nach erfolgreicher Registrierung zum geschützten Dashboard
+      window.location.href = "api/dashboard.php";
     } else {
       alert("Registrierung fehlgeschlagen: " + result.message);
     }

--- a/medikamente.html
+++ b/medikamente.html
@@ -47,7 +47,7 @@
       <h2>Alle Medikamente</h2>
       <div id="medList" class="med-list"></div>
 
-      <a href="dashboard.html" class="back-button">Zurück zum Dashboard</a>
+      <a href="api/dashboard.php" class="back-button">Zurück zum Dashboard</a>
     </div>
   </div>
 

--- a/profile.html
+++ b/profile.html
@@ -26,7 +26,7 @@
       </form>
 
       <div class="buttons">
-        <a href="dashboard.html" class="secondary">Zurück zum Dashboard</a>
+        <a href="api/dashboard.php" class="secondary">Zurück zum Dashboard</a>
         <button id="logoutBtn" class="secondary">Abmelden</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Redirect unauthenticated users by checking `api/profile.php` at the start of dashboard, medikamente, and profile scripts.
- Serve profile and medikamente pages through new PHP endpoints that verify sessions before outputting HTML.
- Point navigation and script redirects to these protected endpoints.

## Testing
- `node --check js/dashboard.js js/medikamente.js js/profile.js js/login.js js/register.js`
- `php -l api/medikamente_page.php api/profile_page.php`


------
https://chatgpt.com/codex/tasks/task_e_68aca5944d1883219c547a6640888514